### PR TITLE
Update Dockerfile with jdk 17 and ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,82 @@
 FROM ubuntu:24.04
+LABEL maintainer="uday kiran reddy"
 
-LABEL maintainer="Bibin Wilson <bibinwilsonn@gmail.com>"
+# Build arguments
+ARG JDK_VERSION=17
+ARG NODE_VERSION=18
+ARG MAVEN_VERSION=3.9.4
 
-# Update packages and install dependencies
+# Environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV JAVA_HOME=/usr/lib/jvm/temurin-${JDK_VERSION}-jdk-amd64
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=$PATH:$MAVEN_HOME/bin
+
+# Make sure the package repository is up to date and install basic tools
 RUN apt-get update && \
     apt-get -qy full-upgrade && \
-    apt-get install -qy git wget gnupg2 software-properties-common && \
-\
-# Install a basic SSH server
-    apt-get install -qy openssh-server && \
+    apt-get install -qy \
+        git \
+        openssh-server \
+        curl \
+        wget \
+        unzip \
+        ca-certificates \
+        build-essential \
+        python3 \
+        python3-pip \
+        gnupg \
+        software-properties-common \
+        apt-transport-https && \
     sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd && \
     mkdir -p /var/run/sshd && \
-\
-# Install OpenJDK 17 from default Ubuntu 24.04 repository
-    apt-get install -qy openjdk-17-jdk && \
-\
-# Install Maven
-    apt-get install -qy maven && \
-\
-# Cleanup
-    apt-get -qy autoremove && \
-\
-# Add user jenkins
+    rm -rf /var/lib/apt/lists/*
+# Install Java (Eclipse Temurin)
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb jammy main" > /etc/apt/sources.list.d/adoptium.list && \
+    apt-get update && \
+    apt-get install -y temurin-${JDK_VERSION}-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Node.js and npm
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    apt-get install -y nodejs
+
+# Install Yarn
+RUN corepack enable && \
+    corepack prepare yarn@stable --activate
+
+# Install Maven (newer version)
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o /tmp/maven.tgz && \
+    tar -xzf /tmp/maven.tgz -C /opt && \
+    ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven && \
+    rm /tmp/maven.tgz
+# Cleanup old packages and add user jenkins to the image
+RUN apt-get -qy autoremove && \
     adduser --quiet jenkins && \
     echo "jenkins:jenkins" | chpasswd && \
-    mkdir -p /home/jenkins/.m2
+    mkdir -p /home/jenkins/.m2 && \
+    mkdir -p /home/jenkins/.ssh
 
-# Copy authorized SSH keys
+#ADD settings.xml /home/jenkins/.m2/
+# Copy authorized keys
 COPY .ssh/authorized_keys /home/jenkins/.ssh/authorized_keys
 
+# Set permissions and verify installations
 RUN chown -R jenkins:jenkins /home/jenkins/.m2/ && \
-    chown -R jenkins:jenkins /home/jenkins/.ssh/
+    chown -R jenkins:jenkins /home/jenkins/.ssh/ && \
+    chmod 700 /home/jenkins/.ssh && \
+    chmod 600 /home/jenkins/.ssh/authorized_keys
+
+# Verify all installations work
+RUN java -version && \
+    mvn -version && \
+    node -v && \
+    npm -v && \
+    yarn -v
+
+# Set working directory
+WORKDIR /workspace
 
 # Standard SSH port
 EXPOSE 22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,32 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Bibin Wilson <bibinwilsonn@gmail.com>"
 
-# Make sure the package repository is up to date.
+# Update packages and install dependencies
 RUN apt-get update && \
     apt-get -qy full-upgrade && \
-    apt-get install -qy git && \
+    apt-get install -qy git wget gnupg2 software-properties-common && \
+\
 # Install a basic SSH server
     apt-get install -qy openssh-server && \
     sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd && \
     mkdir -p /var/run/sshd && \
-# Install JDK 8 (latest stable edition at 2019-04-01)
-    apt-get install -qy openjdk-8-jdk && \
-# Install maven
+\
+# Install OpenJDK 17 from default Ubuntu 24.04 repository
+    apt-get install -qy openjdk-17-jdk && \
+\
+# Install Maven
     apt-get install -qy maven && \
-# Cleanup old packages
+\
+# Cleanup
     apt-get -qy autoremove && \
-# Add user jenkins to the image
+\
+# Add user jenkins
     adduser --quiet jenkins && \
-# Set password for the jenkins user (you may want to alter this).
     echo "jenkins:jenkins" | chpasswd && \
-    mkdir /home/jenkins/.m2
+    mkdir -p /home/jenkins/.m2
 
-#ADD settings.xml /home/jenkins/.m2/
-# Copy authorized keys
+# Copy authorized SSH keys
 COPY .ssh/authorized_keys /home/jenkins/.ssh/authorized_keys
 
 RUN chown -R jenkins:jenkins /home/jenkins/.m2/ && \


### PR DESCRIPTION
Due to updated versions of jenkins where minimum jdk 17 is required, the jdk 8 based image you provided is failing when a jenkins job is spinned.